### PR TITLE
wording on coin and index pages

### DIFF
--- a/src/futuresboard/templates/coin.html
+++ b/src/futuresboard/templates/coin.html
@@ -3,7 +3,7 @@
 {% block title %}{{ coin }}{% endblock %}
 {% block content %}
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-        <h3><i class="fas fa-coins"></i> {{ coin }}</h3><span class="badge bg-secondary"><i class="far fa-clock"></i> LAST CHANGE: {{ lastupdate }}</span>
+        <h3><i class="fas fa-coins"></i> {{ coin }}</h3><span class="badge bg-secondary"><i class="far fa-clock"></i> LAST ORDER: {{ lastupdate }}</span>
         <div class="btn-toolbar mb-2 mb-md-0">
             <div class="btn-group me-2">
                 <form method="GET" name="daterangeform">

--- a/src/futuresboard/templates/home.html
+++ b/src/futuresboard/templates/home.html
@@ -3,7 +3,7 @@
 {% block title %}Dashboard{% endblock %}
 {% block content %}
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-        <h3><i class="fas fa-tachometer-alt"></i> Dashboard</h3> <span class="badge bg-secondary"><i class="far fa-clock"></i> LAST CHANGE: {{ lastupdate }}</span>
+        <h3><i class="fas fa-tachometer-alt"></i> Dashboard</h3> <span class="badge bg-secondary"><i class="far fa-clock"></i> LAST ORDER: {{ lastupdate }}</span>
         <div class="btn-toolbar mb-2 mb-md-0">
             <div class="btn-group me-2">
                 <form method="GET" name="daterangeform">


### PR DESCRIPTION
Change the wording displayed on both home and coins pages from `last change` to `last order` to reflect when the last 'action' occurred on a coin rather than the last time a scrape was run