### PR TITLE
Add Github Actions for publish container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  container_release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/ecoppen/futuresboard
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ACTIONS_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{github.ref_name}}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM python:3.8-buster
 
-WORKDIR /usr/src
-RUN git clone https://github.com/ecoppen/futuresboard.git
+LABEL maintainer="ecoppen" \
+	org.opencontainers.image.url="https://github.com/ecoppen/futuresboard" \
+	org.opencontainers.image.source="https://github.com/ecoppen/futuresboard" \
+	org.opencontainers.image.vendor="ecoppen" \
+	org.opencontainers.image.title="futuresboard" \
+	org.opencontainers.image.description="Dashboard to monitor the performance of your Binance or Bybit Futures account" \
+	org.opencontainers.image.licenses="GPL-3.0"
+
 WORKDIR /usr/src/futuresboard
+COPY . .
 RUN python -m pip install .
 
 CMD futuresboard


### PR DESCRIPTION
Thank you for publishing the awesome projects.

This PR is publishing a container image to ghcr.io using Github Actions.

CI/CD is triggered by pushing tags. And need `ACTIONS_TOKEN` environment variables for pushing container image which is your personal token. You can set this in https://github.com/ecoppen/futuresboard/settings/secrets/actions