### PR TITLE
Catch exception to prevent crashes

### DIFF
--- a/src/futuresboard/scraper.py
+++ b/src/futuresboard/scraper.py
@@ -272,7 +272,7 @@ def create_orders(conn, orders):
 def scrape(app=None):
     try:
         _scrape(app=app)
-    except HTTPRequestError as exc:
+    except (HTTPRequestError, TypeError) as exc:
         if app is None:
             print(exc)
         else:

--- a/src/futuresboard/scraper.py
+++ b/src/futuresboard/scraper.py
@@ -272,7 +272,7 @@ def create_orders(conn, orders):
 def scrape(app=None):
     try:
         _scrape(app=app)
-    except (HTTPRequestError, TypeError) as exc:
+    except (HTTPRequestError, TypeError, KeyError) as exc:
         if app is None:
             print(exc)
         else:

--- a/src/futuresboard/scraper.py
+++ b/src/futuresboard/scraper.py
@@ -526,16 +526,22 @@ def _scrape(app=None):
                 if "rate_limit_status" in responseJSON:
                     weightused = int(responseJSON["rate_limit_status"])
 
-                if responseJSON["result"] is not None:
-                    if responseJSON["result"]["data"] is not None:
-                        for trade in responseJSON["result"]["data"]:
-                            trades[trade["created_at"]] = [
-                                trade["id"],
-                                trade["exec_type"],
-                                trade["closed_pnl"],
-                                trade["order_id"],
-                            ]
-                        if len(responseJSON["result"]["data"]) < 50:
+                if "result" in responseJSON:
+                    if responseJSON["result"] is not None:
+                        if "data" in responseJSON["result"]:
+                            if responseJSON["result"]["data"] is not None:
+                                for trade in responseJSON["result"]["data"]:
+                                    trades[trade["created_at"]] = [
+                                        trade["id"],
+                                        trade["exec_type"],
+                                        trade["closed_pnl"],
+                                        trade["order_id"],
+                                    ]
+                                if len(responseJSON["result"]["data"]) < 50:
+                                    break
+                            else:
+                                break
+                        else:
                             break
                     else:
                         break

--- a/src/futuresboard/scraper.py
+++ b/src/futuresboard/scraper.py
@@ -538,14 +538,19 @@ def _scrape(app=None):
                                         trade["order_id"],
                                     ]
                                 if len(responseJSON["result"]["data"]) < 50:
+                                    app.logger.info("Stop looping pages as data in current page < 50")
                                     break
                             else:
+                                app.logger.warning("'data' not found in responseJSON['result']")
                                 break
                         else:
+                            app.logger.warning("'data' not found in responseJSON['result']")
                             break
                     else:
+                        app.logger.warning("'result' is None")
                         break
                 else:
+                    app.logger.warning("'result' not found in responseJSON")
                     break
 
             if len(trades) > 0:


### PR DESCRIPTION
I encountered crashes from these 2 exceptions a few times now. These crashes can only be resolved by restarting the scraper...

```python
futuresboard_1 [2022-12-02 19:33:43,165] INFO in scraper: Auto scrape routines starting
futuresboard_1 Exception in thread Thread-1:
futuresboard_1 Traceback (most recent call last):
futuresboard_1   File "/usr/local/lib/python3.8/threading.py", line 932, in _bootstrap_inner
futuresboard_1     self.run()
futuresboard_1   File "/usr/local/lib/python3.8/threading.py", line 870, in run
futuresboard_1     self._target(*self._args, **self._kwargs)
futuresboard_1   File "/usr/local/lib/python3.8/site-packages/futuresboard/scraper.py", line to_scrape
futuresboard_1     scrape(app=app)
futuresboard_1   File "/usr/local/lib/python3.8/site-packages/futuresboard/scraper.py", line rape
futuresboard_1     _scrape(app=app)
futuresboard_1   File "/usr/local/lib/python3.8/site-packages/futuresboard/scraper.py", line crape
futuresboard_1     if responseJSON["result"]["data"] is not None:
futuresboard_1 KeyError: 'data'
```